### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dgzlopes


### PR DESCRIPTION
Sets `@dgzlopes` as the default code owner for all paths.

Closes the gap of having no `CODEOWNERS` file in this repo — review assignment will now route automatically.